### PR TITLE
feat: increase security of session cookie [BLAC-199]

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-Rails.application.config.session_store :active_record_store, key: "_catalogue_session", domain: :all, httponly: true
+Rails.application.config.session_store :active_record_store, key: "_catalogue_session", secure: Rails.env.production?, httponly: true, samesite: {lax: true}
 
 # This needs to be set after initialisation, otherwise the model classes won't be loaded
 # and an error will be thrown regarding CatalogueSession not being found.


### PR DESCRIPTION
"secure" option is only set to "true" in production to allow for unsecured local development and lower environments.