### PR TITLE
fix: post login redirect resolution

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h1>Login</h1>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, html: {'data-turbo' => "false"}, url: session_path(resource_name)) do |f| %>
   <div class="field form-group">
     <%= f.label :username, "User ID" %>
     <%= f.text_field :username, autofocus: true, autocomplete: "username",class: "form-control col-md-4" %>

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe "Login" do
     expect(page).to have_link("here", href: ENV["NATIONAL_LIBRARY_CARD_URL"])
   end
 
+  it "disables Turbo" do
+    visit new_user_session_path
+
+    expect(page).to have_css("form[data-turbo]")
+  end
+
   context "when user is inactive" do
     it "displays an error message" do
       visit root_path


### PR DESCRIPTION
Unless the `data-turbo` html attribute on the sign in form is set to `false`, Devise will submit the form using the TURBO_STREAM format and the redirect to the previously visited URL will also be requested in TURBO_STREAM format.

Plain Rails redirects only use HTML format, so any redirects triggered by a TURBO_STREAM request will not resolve.